### PR TITLE
Feature/migrate GUI matching to protocol-only; add Excel→ITransaction adapter; explainable matcher; hardened number parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: forbid-delete-markers
+        name: Forbid DELETE_ME markers
+        language: pygrep
+        entry: \b(DELETE_ME|REMOVE_BEFORE_MERGE)\b
+        types: [python]               # only scan .py files
+        exclude: ^(logs/|docs/)       # ignore these paths (optional)
+      - id: forbid-delete-blocks
+        name: Forbid pending DELETE blocks
+        language: pygrep
+        entry: '^\s*#\s*region\s*DELETE_BLOCK:\s*start\b'
+        types: [python]

--- a/quicken_helper/controllers/transaction_compare.py
+++ b/quicken_helper/controllers/transaction_compare.py
@@ -1,0 +1,114 @@
+# quicken_helper/controllers/transaction_compare.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from difflib import SequenceMatcher
+from typing import Dict, List, Optional
+
+from quicken_helper.data_model.interfaces import ITransaction
+
+
+# Tunables: mirror your historical auto_match behavior
+_AMOUNT_MUST_MATCH: bool = True      # legacy gate: require exact amount
+_MAX_POSITIVE: int = 200             # cap for positive score
+_W_DATE_PER_DAY: int = 5             # points lost per day of delta (lower is stricter)
+_W_PAYEE_MAX: int = 80               # max points contributed by payee match if amounts equal
+_W_DATE_BASE: int = 100              # base credit when dates are identical (when amounts equal)
+
+
+@dataclass(frozen=True)
+class MatchScore:
+    """Composite score & explainability for a candidate ITransaction pair."""
+    score: int                    # higher is better
+    reasons: List[str]            # human-readable components explaining the score
+    features: Dict[str, object]   # raw numbers to aid debugging/thresholding
+
+
+def _norm(s: Optional[str]) -> str:
+    if not s:
+        return ""
+    # basic normalization: strip punctuation-like chars, collapse spaces, lowercase
+    out = []
+    for ch in s.lower():
+        out.append(ch if ch.isalnum() or ch.isspace() else " ")
+    return " ".join("".join(out).split())
+
+
+def _payee_similarity(a: str, b: str) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(a=_norm(a), b=_norm(b)).ratio()
+
+
+def _date_delta_days(d1: Optional[date], d2: Optional[date]) -> Optional[int]:
+    if d1 is None or d2 is None:
+        return None
+    return abs((d1 - d2).days)
+
+
+def compare_txn(a: ITransaction, b: ITransaction) -> MatchScore:
+    """
+    Compare two ITransaction objects using the legacy auto_match heuristics:
+
+    1) Amount equality is a hard gate (historically the candidate pre-filter).
+    2) Among equal-amount candidates, prefer closer dates (lower day delta).
+    3) Break ties with normalized payee similarity.
+
+    Returns a MatchScore with a single scalar 'score' suitable for sorting
+    (higher is better), plus 'reasons' and raw 'features' for explainability.
+    """
+    # --- Features ---
+    amount_a: Decimal = a.amount
+    amount_b: Decimal = b.amount
+    amount_diff: Decimal = (amount_a - amount_b).copy_abs()
+
+    date_days: Optional[int] = _date_delta_days(a.date, b.date)
+    payee_sim: float = _payee_similarity(getattr(a, "payee", ""), getattr(b, "payee", ""))
+
+    reasons: List[str] = []
+    features: Dict[str, object] = {
+        "amount_a": str(amount_a),
+        "amount_b": str(amount_b),
+        "amount_diff": str(amount_diff),
+        "date_a": a.date.isoformat() if getattr(a, "date", None) else None,
+        "date_b": b.date.isoformat() if getattr(b, "date", None) else None,
+        "date_days": date_days,
+        "payee_a": getattr(a, "payee", ""),
+        "payee_b": getattr(b, "payee", ""),
+        "payee_sim": round(payee_sim, 3),
+    }
+
+    # --- Amount gate (legacy behavior) ---
+    if _AMOUNT_MUST_MATCH and amount_diff != 0:
+        reasons.append(f"Amount differs by {amount_diff}")
+        # Negative score to ensure these lose against any equal-amount candidate.
+        return MatchScore(score=-1000, reasons=reasons, features=features)
+
+    # --- Score construction for equal-amount candidates ---
+    score: int = 0
+
+    # Date proximity: identical date gets full base; each day away costs points.
+    if date_days is not None:
+        date_points = max(0, _W_DATE_BASE - _W_DATE_PER_DAY * date_days)
+        score += date_points
+        if date_days == 0:
+            reasons.append("Same date (+{})".format(date_points))
+        else:
+            reasons.append(f"{date_days} day(s) apart (+{date_points})")
+    else:
+        # No dates → neutral on date; still explain.
+        reasons.append("No date on one side (+0)")
+
+    # Payee similarity: up to W_PAYEE_MAX additional points.
+    payee_points = int(round(_W_PAYEE_MAX * payee_sim))
+    score += payee_points
+    reasons.append(f"Payee similarity {payee_sim:.2f} (+{payee_points})")
+
+    # Soft cap to keep scores comparable
+    score = min(score, _MAX_POSITIVE)
+
+    return MatchScore(score=score, reasons=reasons, features=features)

--- a/quicken_helper/data_model/excel/__init__.py
+++ b/quicken_helper/data_model/excel/__init__.py
@@ -1,5 +1,6 @@
 # quicken_helper/data_model/excel/__init__.py
 from .excel_row import ExcelRow
 from .excel_txn_group import ExcelTxnGroup
+from .excel_transaction import ExcelTransaction
 
-__all__ = ["ExcelRow", "ExcelTxnGroup"]
+__all__ = ["ExcelRow", "ExcelTxnGroup", "ExcelTransaction"]

--- a/quicken_helper/data_model/excel/__init__.py
+++ b/quicken_helper/data_model/excel/__init__.py
@@ -1,6 +1,6 @@
 # quicken_helper/data_model/excel/__init__.py
 from .excel_row import ExcelRow
 from .excel_txn_group import ExcelTxnGroup
-from .excel_transaction import ExcelTransaction
+from .excel_transaction import ExcelTransaction, map_group_to_excel_txn
 
-__all__ = ["ExcelRow", "ExcelTxnGroup", "ExcelTransaction"]
+__all__ = ["ExcelRow", "ExcelTxnGroup", "ExcelTransaction", "map_group_to_excel_txn"]

--- a/quicken_helper/data_model/excel/excel_transaction.py
+++ b/quicken_helper/data_model/excel/excel_transaction.py
@@ -1,21 +1,109 @@
 # quicken_helper/data_model/excel/excel_transaction.py
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
-from typing import List, Optional
-from quicken_helper.data_model.interfaces import ITransaction, EnumClearedStatus, ISplit
+from typing import Iterable, List, Optional
+
+from quicken_helper.data_model.interfaces import ITransaction, ISplit, EnumClearedStatus
+from quicken_helper.data_model.excel.excel_txn_group import ExcelTxnGroup
+from quicken_helper.data_model.excel.excel_row import ExcelRow
+from quicken_helper.utilities.converters_scalar import _to_decimal
+
+
+# --------------------------- Concrete adapters ---------------------------
+
+@dataclass(frozen=True)
+class ExcelSplit(ISplit):
+    """Adapter for a single Excel row as a split line."""
+    category: str = ""
+    memo: str = ""
+    amount: Decimal = Decimal("0")
+
 
 @dataclass(frozen=True)
 class ExcelTransaction(ITransaction):
-    """Adapter: an Excel group exposed as an ITransaction."""
+    """Adapter exposing an Excel group as a single ITransaction."""
     id: str
     date: date
     amount: Decimal
     payee: str = ""
     memo: str = ""
+    # When splits exist, parent category is typically empty in QIF semantics.
     category: str = ""
+    # Use default_factory to avoid dataclass complaints about enum defaults.
     cleared: EnumClearedStatus = field(default_factory=lambda: EnumClearedStatus.UNKNOWN)
     splits: Optional[List[ISplit]] = None
-    action: Optional[str] = None  # for symmetry; probably None for Excel
+    action: Optional[str] = None  # Usually None for Excel-originated txns
 
-    # Any normalization needed for matching should be done upstream or via helpers.
+
+# ------------------------------ Mapper ----------------------------------
+
+def map_group_to_excel_txn(group: ExcelTxnGroup) -> ITransaction:
+    """
+    Convert an ExcelTxnGroup (with one or more ExcelRow items) into a single ITransaction.
+
+    Mapping rules:
+      • id      ← group.gid
+      • date    ← group.date
+      • amount  ← group.total_amount (coerced to Decimal)
+      • payee   ← first non-empty row.item (fallback: "")
+      • memo    ← unique row.rationale values joined with "; " (fallback: "")
+      • splits  ← one ExcelSplit per row: {category=row.category, memo=row.item or row.rationale, amount=row.amount}
+      • category (parent) left blank when splits present (typical QIF behavior).
+      • cleared ← EnumClearedStatus.UNKNOWN
+      • action  ← None (Excel groups generally have no investment action)
+    """
+    # Defensive coercions (support Decimal/str totals)
+    total: Decimal
+    if isinstance(group.total_amount, Decimal):
+        total = group.total_amount
+    else:
+        total = _to_decimal(group.total_amount)
+
+    rows: Iterable[ExcelRow] = getattr(group, "rows", ()) or ()
+
+    # Payee: first non-empty item
+    payee_candidates = (getattr(r, "item", "") for r in rows)
+    payee = next((p for p in payee_candidates if p), "")
+
+    # Memo: distinct rationales, joined
+    rat_list = [getattr(r, "rationale", "") for r in rows if getattr(r, "rationale", "")]
+    # preserve order while deduping
+    seen = set()
+    uniq_rats: List[str] = []
+    for r in rat_list:
+        if r not in seen:
+            seen.add(r)
+            uniq_rats.append(r)
+    memo = "; ".join(uniq_rats)
+
+    # Splits: one per row
+    split_list: List[ISplit] = []
+    for r in rows:
+        amt = r.amount if isinstance(r.amount, Decimal) else _to_decimal(r.amount)
+        # Prefer row.item as the line memo; fall back to rationale if item is empty.
+        line_memo = getattr(r, "item", "") or getattr(r, "rationale", "")
+        split_list.append(ExcelSplit(category=getattr(r, "category", "") or "", memo=line_memo, amount=amt))
+
+    # Parent category: leave empty when we have splits; otherwise can mirror a single-row category.
+    parent_category = ""
+    if not split_list:
+        # No rows → keep empty; if you prefer to propagate a group-level category, add it here.
+        parent_category = ""
+    elif len(split_list) == 1:
+        # Single split: you may choose to bubble up its category (optional).
+        # parent_category = split_list[0].category
+        parent_category = ""  # keep empty for consistency with split semantics
+
+    return ExcelTransaction(
+        id=str(getattr(group, "gid", "")),
+        date=getattr(group, "date"),
+        amount=total,
+        payee=payee,
+        memo=memo,
+        category=parent_category,
+        splits=split_list or None,
+        # cleared defaults to UNKNOWN; action remains None
+    )

--- a/quicken_helper/data_model/excel/excel_transaction.py
+++ b/quicken_helper/data_model/excel/excel_transaction.py
@@ -1,0 +1,21 @@
+# quicken_helper/data_model/excel/excel_transaction.py
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import List, Optional
+from quicken_helper.data_model.interfaces import ITransaction, EnumClearedStatus, ISplit
+
+@dataclass(frozen=True)
+class ExcelTransaction(ITransaction):
+    """Adapter: an Excel group exposed as an ITransaction."""
+    id: str
+    date: date
+    amount: Decimal
+    payee: str = ""
+    memo: str = ""
+    category: str = ""
+    cleared: EnumClearedStatus = field(default_factory=lambda: EnumClearedStatus.UNKNOWN)
+    splits: Optional[List[ISplit]] = None
+    action: Optional[str] = None  # for symmetry; probably None for Excel
+
+    # Any normalization needed for matching should be done upstream or via helpers.

--- a/quicken_helper/data_model/q_wrapper/q_transaction.py
+++ b/quicken_helper/data_model/q_wrapper/q_transaction.py
@@ -35,7 +35,7 @@ class QTransaction(ITransaction):
     date: date = date(1985, 11, 5)
     action_chk: str = field(default_factory=str)
     amount: Decimal = Decimal(0)
-    cleared: EnumClearedStatus = field(default_factory=EnumClearedStatus)
+    cleared: EnumClearedStatus = field(default_factory=lambda: EnumClearedStatus.UNKNOWN)
     payee: str = field(default_factory=str)
     memo: str = field(default_factory=str)
     category: str = field(default_factory=str)

--- a/quicken_helper/gui_viewers/app.py
+++ b/quicken_helper/gui_viewers/app.py
@@ -29,7 +29,13 @@ from quicken_helper.legacy import qfx_to_txns as qfx
 from quicken_helper.legacy import qif_writer as mod
 
 from .scaling import apply_global_font_scaling
+import logging
+import logging.config
+from quicken_helper.utilities import LOGGING
 
+
+logging.config.dictConfig(LOGGING)
+log = logging.getLogger(__name__)
 
 class App(tk.Tk):
     """

--- a/quicken_helper/utilities/data_conversion.py
+++ b/quicken_helper/utilities/data_conversion.py
@@ -1,0 +1,10 @@
+# quicken_helper/utilities/data_conversion.py
+
+from quicken_helper.utilities.core_util import convert_value
+from quicken_helper.data_model.interfaces import ITransaction
+
+def as_transaction(x) -> ITransaction:
+    # Leverage _PROTOCOL_IMPLEMENTATION map in core_util
+    return convert_value(ITransaction, x)
+
+

--- a/tests/controllers/test_match_session.py
+++ b/tests/controllers/test_match_session.py
@@ -1,511 +1,207 @@
 from __future__ import annotations
 
-from _decimal import Decimal
-from datetime import date
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import List
 
-# from quicken_helper.qif_txn_view import QIFTxnView
-from quicken_helper.controllers.match_session import MatchSession, TxnLegacyView
-from quicken_helper.data_model.excel.excel_row import ExcelRow
-from quicken_helper.data_model.excel.excel_txn_group import ExcelTxnGroup
+import pytest
 
-
-def _mk_tx(datestr: str, amt: str, **extras):
-    """Small helper to build a QIF txn dict quickly."""
-    base = {"date": datestr, "amount": amt, "payee": "P", "memo": "", "category": ""}
-    base.update(extras)
-    return base
+# System under test
+import quicken_helper.controllers.match_session as ms
 
 
-def _mk_group(rows, gid=None) -> ExcelTxnGroup:
+# ---- Lightweight protocol-shaped stub ---------------------------------------
+
+@dataclass(frozen=True)
+class StubTxn:
+    """Minimal ITransaction-shaped stub for tests (date, amount, payee only)."""
+    date: date
+    amount: Decimal
+    payee: str = ""
+
+
+# ---- Helpers -----------------------------------------------------------------
+
+def _mk_bank(*rows: tuple[str, str, str]) -> List[StubTxn]:
     """
-    Build an ExcelTxnGroup from a non-empty list of ExcelRow by summing amounts
-    and using the first row's date. Provides deterministic construction that
-    avoids any factory method dependency.
+    Build bank txns from triples: (YYYY-MM-DD, amount_str, payee).
     """
-    assert rows, "rows must not be empty"
-    group_id = gid if gid is not None else rows[0].txn_id
-    total = sum((r.amount for r in rows), Decimal("0"))
-    # return ExcelTxnGroup(gid=group_id, date=rows[0].date, total_amount=total, rows=tuple(rows))
-    return ExcelTxnGroup(
-        gid=(gid if gid is not None else rows[0].txn_id),
-        date=rows[0].date,
-        total_amount=total,
-        rows=tuple(rows),
-    )
+    out: List[StubTxn] = []
+    for d, a, p in rows:
+        y, m, dd = map(int, d.split("-"))
+        out.append(StubTxn(date=date(y, m, dd), amount=Decimal(a), payee=p))
+    return out
 
 
-# ---------------------------------------------------------------------------
-# Group-mode (split-aware) tests
-# ---------------------------------------------------------------------------
+def _mk_excel(*rows: tuple[str, str, str]) -> List[StubTxn]:
+    """
+    Build excel txns from triples: (YYYY-MM-DD, amount_str, payee).
+    """
+    return _mk_bank(*rows)
 
 
-def test_auto_match_groups_matches_by_total_and_date_window():
-    # Arrange
-    txns = [
-        _mk_tx("2025-08-01", "-50.00"),  # will match G1 (sum -30 + -20)
-        _mk_tx("2025-08-02", "-20.00"),  # will match G2 (sum -20)
-    ]
+# ---- Fixtures ----------------------------------------------------------------
 
-    rows_g1 = [
-        ExcelRow(
-            idx=0,
-            txn_id="G1",
-            date=date(2025, 8, 1),
-            amount=Decimal("-30.00"),
-            item="A1",
-            category="Food:A",
-            rationale="r1",
-        ),
-        ExcelRow(
-            idx=1,
-            txn_id="G1",
-            date=date(2025, 8, 1),
-            amount=Decimal("-20.00"),
-            item="A2",
-            category="Food:B",
-            rationale="r2",
-        ),
-    ]
-    rows_g2 = [
-        ExcelRow(
-            idx=2,
-            txn_id="G2",
-            date=date(2025, 8, 2),
-            amount=Decimal("-20.00"),
-            item="B1",
-            category="Food:C",
-            rationale="r3",
-        ),
-    ]
-    g1 = _mk_group(rows_g1, gid="G1")
-    g2 = _mk_group(rows_g2, gid="G2")
-    session = MatchSession(txns, excel_groups=[g1, g2])
+@pytest.fixture(autouse=True)
+def _isolate_convert_value(monkeypatch):
+    """
+    Isolation: stub out convert_value so tests don't depend on concrete implementations
+    or the _PROTOCOL_IMPLEMENTATION mapping. It becomes identity.
+    """
+    monkeypatch.setattr(ms, "convert_value", lambda _t, v: v)
+
+
+# ---- Tests -------------------------------------------------------------------
+
+def test_constructor_coerces_to_protocol_and_preserves_order():
+    """Positive: constructor coerces inputs and preserves element identity/order."""
+    bank = _mk_bank(("2025-08-01", "10.00", "A"), ("2025-08-02", "20.00", "B"))
+    excel = _mk_excel(("2025-08-01", "10.00", "A*"), ("2025-08-03", "30.00", "C"))
 
     # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
+    s = ms.MatchSession(bank, excel)
 
     # Assert
-    assert (
-        len(pairs) == 2
-    ), "Both transactions should auto-match by total and ±3 day window."
-    for q, grp, cost in pairs:
-        # assert isinstance(q, QIFTxnView)
-        assert isinstance(q, TxnLegacyView)
-        assert isinstance(grp, ExcelTxnGroup)
-        assert (
-            q.amount == grp.total_amount
-        ), "Transaction must match its group's total amount."
-        assert cost in (0, 1, 2, 3), "Date cost should be within ±3 days."
+    assert s.bank_txns[0] is bank[0]
+    assert s.bank_txns[1] is bank[1]
+    assert s.excel_txns[0] is excel[0]
+    assert s.excel_txns[1] is excel[1]
 
 
-def test_auto_match_groups_prefers_in_window_and_ignores_out_of_window():
-    # Arrange
-    txns = [
-        _mk_tx("2025-08-01", "-42.00"),
-    ]
-    # One candidate out of window (10 days away)
-    g_far = _mk_group(
-        [
-            ExcelRow(
-                idx=0,
-                txn_id="Z1",
-                date=date(2025, 8, 11),
-                amount=Decimal("-42.00"),
-                item="x",
-                category="C",
-                rationale="far",
-            ),
-        ],
-        gid="Z1",
+def test_auto_match_basic_equal_amount_and_date_tie_break():
+    """Positive: auto_match pairs equal-amount txns, preferring closest date then payee similarity."""
+    # Arrange: bank has two amounts; excel has same amounts but dates/payees vary
+    bank = _mk_bank(
+        ("2025-08-01", "10.00", "Acme"),
+        ("2025-08-10", "20.00", "Globex"),
     )
-    # One candidate inside window (1 day away)
-    g_near = _mk_group(
-        [
-            ExcelRow(
-                idx=1,
-                txn_id="Z2",
-                date=date(2025, 8, 2),
-                amount=Decimal("-42.00"),
-                item="y",
-                category="C",
-                rationale="near",
-            ),
-        ],
-        gid="Z2",
+    excel = _mk_excel(
+        ("2025-08-02", "10.00", "Acme LLC"),   # 1 day apart, good payee sim
+        ("2025-08-04", "10.00", "Random"),     # 3 days apart, poor sim
+        ("2025-08-12", "20.00", "Globex Inc"), # 2 days apart
     )
-
-    session = MatchSession(txns, excel_groups=[g_far, g_near])
-
-    # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
-
-    # Assert
-    assert len(pairs) == 1, "Only the in-window group should be selected."
-    q, grp, cost = pairs[0]
-    assert grp.gid == "Z2", "The group within ±3 days should be preferred."
-    assert cost in (0, 1, 2, 3)
-
-
-def test_unmatched_helpers_return_only_unmatched_items_in_group_mode():
-    # Arrange
-    txns = [
-        _mk_tx("2025-07-01", "-30.00"),  # will match
-        _mk_tx("2025-07-02", "-20.00"),  # will be unmatched
-    ]
-    matched_group = _mk_group(
-        [
-            ExcelRow(
-                idx=0,
-                txn_id="A",
-                date=date(2025, 7, 1),
-                amount=Decimal("-30.00"),
-                item="i1",
-                category="C1",
-                rationale="R1",
-            ),
-        ],
-        gid="A",
-    )
-    # Same total but outside date window → remains unmatched
-    unmatched_group = _mk_group(
-        [
-            ExcelRow(
-                idx=1,
-                txn_id="B",
-                date=date(2025, 8, 1),
-                amount=Decimal("-20.00"),
-                item="i2",
-                category="C2",
-                rationale="R2",
-            ),
-        ],
-        gid="B",
-    )
-
-    session = MatchSession(txns, excel_groups=[matched_group, unmatched_group])
+    s = ms.MatchSession(bank, excel)
 
     # Act
-    session.auto_match()
-    unmatched_q = session.unmatched_qif()
-    unmatched_e = session.unmatched_excel()
+    pairs = s.auto_match()
 
-    # Assert
-    assert len(session.matched_pairs()) == 1
-    # QIF unmatched should contain the second txn (date 2025-07-02)
-    assert len(unmatched_q) == 1 and unmatched_q[0].date.isoformat() == "2025-07-02"
-    # Excel unmatched should contain only the second (out-of-window) group
-    assert len(unmatched_e) == 1 and isinstance(unmatched_e[0], ExcelTxnGroup)
-    assert unmatched_e[0].gid == unmatched_group.gid
-
-
-# ---------------------------------------------------------------------------
-# Legacy row-mode tests (fallback)
-# ---------------------------------------------------------------------------
-
-
-def test_legacy_row_mode_auto_match_by_amount_and_date():
-    # Arrange
-    txns = [
-        _mk_tx("2025-08-01", "-10.00"),
-        _mk_tx("2025-08-02", "-20.00"),
-    ]
-    rows = [
-        ExcelRow(
-            idx=0,
-            txn_id="r1",
-            date=date(2025, 8, 1),
-            amount=Decimal("-10.00"),
-            item="x1",
-            category="C1",
-            rationale="R1",
-        ),
-        ExcelRow(
-            idx=1,
-            txn_id="r2",
-            date=date(2025, 8, 2),
-            amount=Decimal("-20.00"),
-            item="x2",
-            category="C2",
-            rationale="R2",
-        ),
-    ]
-    session = MatchSession(txns, excel_rows=rows)
-
-    # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
-
-    # Assert
-    assert (
-        len(pairs) == 2
-    ), "Both transactions should match legacy rows by amount and date."
-    assert all(
-        isinstance(p[1], ExcelRow) for p in pairs
-    ), "Legacy mode should return ExcelRow in pairs."
-    assert all(
-        p[2] in (0, 1, 2, 3) for p in pairs
-    ), "Date cost should be within ±3 days."
-
-
-def test_auto_match_group_with_three_splits_matches_total_and_window():
-    # Arrange: txn −60.00 should match group G (−20 −20 −20) on 2025-08-10 vs 2025-08-12 (±2 days)
-    txns = [_mk_tx("2025-08-10", "-60.00")]
-    rows_g = [
-        ExcelRow(
-            idx=0,
-            txn_id="G",
-            date=date(2025, 8, 12),
-            amount=Decimal("-20.00"),
-            item="a",
-            category="X",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=1,
-            txn_id="G",
-            date=date(2025, 8, 12),
-            amount=Decimal("-20.00"),
-            item="b",
-            category="Y",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=2,
-            txn_id="G",
-            date=date(2025, 8, 12),
-            amount=Decimal("-20.00"),
-            item="c",
-            category="Z",
-            rationale="r",
-        ),
-    ]
-    g = _mk_group(rows_g, gid="G")
-    session = MatchSession(txns, excel_groups=[g])
-
-    # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
-
-    # Assert: total must match and date cost within 0..3 days
-    assert len(pairs) == 1
-    q, grp, cost = pairs[0]
-    assert isinstance(q, TxnLegacyView) and grp.gid == "G"
-    assert q.amount == grp.total_amount and cost in (0, 1, 2, 3)
-
-
-def test_auto_match_tie_breaks_equal_cost_by_group_index_deterministically():
-    # Arrange: both groups sum to −40 and are ±1 day away; earlier index should win.
-    txns = [_mk_tx("2025-08-10", "-40.00")]
-
-    # g0: date 2025-08-11, two splits
-    g0_rows = [
-        ExcelRow(
-            idx=0,
-            txn_id="A",
-            date=date(2025, 8, 11),
-            amount=Decimal("-15.00"),
-            item="x",
-            category="C",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=1,
-            txn_id="A",
-            date=date(2025, 8, 11),
-            amount=Decimal("-25.00"),
-            item="y",
-            category="C",
-            rationale="r",
-        ),
-    ]
-    g0 = _mk_group(g0_rows, gid="A")
-
-    # g1: date 2025-08-09, three splits (same total, same |date diff| = 1)
-    g1_rows = [
-        ExcelRow(
-            idx=2,
-            txn_id="B",
-            date=date(2025, 8, 9),
-            amount=Decimal("-10.00"),
-            item="u",
-            category="C",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=3,
-            txn_id="B",
-            date=date(2025, 8, 9),
-            amount=Decimal("-15.00"),
-            item="v",
-            category="C",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=4,
-            txn_id="B",
-            date=date(2025, 8, 9),
-            amount=Decimal("-15.00"),
-            item="w",
-            category="C",
-            rationale="r",
-        ),
-    ]
-    g1 = _mk_group(g1_rows, gid="B")
-
-    # Put g0 first so its group index gi=0 — ties on (cost, ti) should pick lower gi.
-    session = MatchSession(txns, excel_groups=[g0, g1])
-
-    # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
-
-    # Assert: chooses g0 (index 0) on equal date-cost (deterministic tie-break by gi)
-    assert len(pairs) == 1
-    _, grp, cost = pairs[0]
-    assert grp.gid == "A"
-    assert cost in (0, 1, 2, 3)
-
-
-def test_auto_match_multiple_txns_respects_one_to_one_when_many_groups_exist():
-    # Arrange: two txns needing −30 each; three candidate groups exist (each −30).
-    txns = [
-        _mk_tx("2025-08-05", "-30.00"),
-        _mk_tx("2025-08-06", "-30.00"),
-    ]
-    # Three groups, all within window, each with multiple splits
-    g_rows = [
-        [
-            ExcelRow(
-                idx=0,
-                txn_id="G1",
-                date=date(2025, 8, 5),
-                amount=Decimal("-10.00"),
-                item="a1",
-                category="C",
-                rationale="r",
-            ),
-            ExcelRow(
-                idx=1,
-                txn_id="G1",
-                date=date(2025, 8, 5),
-                amount=Decimal("-20.00"),
-                item="a2",
-                category="C",
-                rationale="r",
-            ),
-        ],
-        [
-            ExcelRow(
-                idx=2,
-                txn_id="G2",
-                date=date(2025, 8, 6),
-                amount=Decimal("-12.00"),
-                item="b1",
-                category="C",
-                rationale="r",
-            ),
-            ExcelRow(
-                idx=3,
-                txn_id="G2",
-                date=date(2025, 8, 6),
-                amount=Decimal("-18.00"),
-                item="b2",
-                category="C",
-                rationale="r",
-            ),
-        ],
-        [
-            ExcelRow(
-                idx=4,
-                txn_id="G3",
-                date=date(2025, 8, 7),
-                amount=Decimal("-15.00"),
-                item="c1",
-                category="C",
-                rationale="r",
-            ),
-            ExcelRow(
-                idx=5,
-                txn_id="G3",
-                date=date(2025, 8, 7),
-                amount=Decimal("-15.00"),
-                item="c2",
-                category="C",
-                rationale="r",
-            ),
-        ],
-    ]
-    g1, g2, g3 = (
-        _mk_group(g_rows[0], gid="G1"),
-        _mk_group(g_rows[1], gid="G2"),
-        _mk_group(g_rows[2], gid="G3"),
-    )
-    session = MatchSession(txns, excel_groups=[g1, g2, g3])
-
-    # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
-
-    # Assert: exactly two pairs; each Excel group used at most once (one-to-one)
+    # Assert: should match (10→first excel 10, 20→its excel 20)
     assert len(pairs) == 2
-    used_gids = {grp.gid for _, grp, _ in pairs}
-    assert used_gids.issubset({"G1", "G2", "G3"}) and len(used_gids) == 2
+    assert pairs[0][0] is bank[0] and pairs[0][1] is excel[0]
+    assert pairs[1][0] is bank[1] and pairs[1][1] is excel[2]
+    # Unmatched lists should be empty
+    assert s.unmatched_bank == []
+    assert s.unmatched_excel == [excel[1]]
 
 
-def test_auto_match_ignores_multi_split_group_outside_window_even_if_totals_match():
-    # Arrange: txn −50.00; two groups total −50.00, but only one is within ±3 days.
-    txns = [_mk_tx("2025-08-10", "-50.00")]
-    g_far_rows = [
-        ExcelRow(
-            idx=0,
-            txn_id="Z1",
-            date=date(2025, 8, 20),
-            amount=Decimal("-20.00"),
-            item="x",
-            category="C",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=1,
-            txn_id="Z1",
-            date=date(2025, 8, 20),
-            amount=Decimal("-30.00"),
-            item="y",
-            category="C",
-            rationale="r",
-        ),
-    ]
-    g_near_rows = [
-        ExcelRow(
-            idx=2,
-            txn_id="Z2",
-            date=date(2025, 8, 11),
-            amount=Decimal("-25.00"),
-            item="u",
-            category="C",
-            rationale="r",
-        ),
-        ExcelRow(
-            idx=3,
-            txn_id="Z2",
-            date=date(2025, 8, 11),
-            amount=Decimal("-25.00"),
-            item="v",
-            category="C",
-            rationale="r",
-        ),
-    ]
-    g_far = _mk_group(g_far_rows, gid="Z1")
-    g_near = _mk_group(g_near_rows, gid="Z2")
-    session = MatchSession(txns, excel_groups=[g_far, g_near])
+def test_auto_match_respects_threshold_and_rejects_low_scores(monkeypatch):
+    """Negative: setting a very high threshold yields no matches."""
+    # Arrange: equal amounts but far dates → very low scores
+    bank = _mk_bank(("2025-01-01", "50.00", "X"))
+    excel = _mk_excel(("2025-03-01", "50.00", "X"))  # 59 days apart
+    s = ms.MatchSession(bank, excel)
 
     # Act
-    session.auto_match()
-    pairs = session.matched_pairs()
+    pairs = s.auto_match(min_score=9999)
 
-    # Assert: only the in-window group is matched
-    assert len(pairs) == 1
-    _, grp, cost = pairs[0]
-    assert grp.gid == "Z2" and cost in (0, 1, 2, 3)
+    # Assert
+    assert pairs == []
+    assert s.unmatched_bank == bank
+    assert s.unmatched_excel == excel
+
+
+def test_manual_match_overrides_and_is_one_to_one():
+    """Positive: manual_match enforces one-to-one by unhooking conflicting pairs."""
+    bank = _mk_bank(
+        ("2025-08-01", "10.00", "A"),
+        ("2025-08-02", "20.00", "B"),
+    )
+    excel = _mk_excel(
+        ("2025-08-01", "10.00", "A1"),
+        ("2025-08-02", "20.00", "B1"),
+    )
+    s = ms.MatchSession(bank, excel)
+    s.auto_match()  # will pair (0->0) and (1->1)
+
+    # Act: force bank[0] to pair with excel[1]
+    s.manual_match(bank_index=0, excel_index=1)
+
+    # Assert: bank[1] must be unpaired now
+    pairs = s.pairs
+    assert pairs == [(bank[0], excel[1])]
+    assert s.unmatched_bank == [bank[1]]
+    assert s.unmatched_excel == [excel[0]]
+
+
+def test_manual_unmatch_by_bank_and_excel():
+    """Positive: manual_unmatch removes pairs by either side's index."""
+    bank = _mk_bank(("2025-08-01", "10.00", "A"))
+    excel = _mk_excel(("2025-08-01", "10.00", "A1"))
+    s = ms.MatchSession(bank, excel)
+    s.auto_match()
+    assert s.pairs  # sanity
+
+    # Act / Assert (by bank)
+    s.manual_unmatch(bank_index=0)
+    assert s.pairs == []
+    assert s.unmatched_bank == bank
+    assert s.unmatched_excel == excel
+
+    # Re-pair and unmatch by excel index
+    s.manual_match(bank_index=0, excel_index=0)
+    s.manual_unmatch(excel_index=0)
+    assert s.pairs == []
+    assert s.unmatched_bank == bank
+    assert s.unmatched_excel == excel
+
+
+def test_nonmatch_reason_reports_when_no_equal_amount_candidates():
+    """Negative: nonmatch_reason clearly reports when there are no equal-amount candidates."""
+    bank = _mk_bank(("2025-08-01", "10.00", "Acme"))
+    excel = _mk_excel(("2025-08-01", "11.00", "Acme"))  # different amount
+    s = ms.MatchSession(bank, excel)
+
+    # Act
+    msg = s.nonmatch_reason(bank_index=0)
+
+    # Assert
+    assert "No equal-amount candidates" in msg
+    assert "10.00" in msg  # includes target amount
+
+
+def test_nonmatch_reason_includes_best_candidate_features():
+    """Positive: nonmatch_reason includes score, date delta, and payee similarity with reasons."""
+    bank = _mk_bank(("2025-08-10", "25.00", "Globex"))
+    # Same amount candidates: one is closer in date, another with worse payee
+    excel = _mk_excel(
+        ("2025-08-12", "25.00", "Globex Inc"),   # 2 days apart, similar payee
+        ("2025-08-20", "25.00", "Different"),    # 10 days apart, poor payee
+    )
+    s = ms.MatchSession(bank, excel)
+
+    # Act
+    msg = s.nonmatch_reason(bank_index=0)
+
+    # Assert
+    assert "Best candidate index 0" in msg  # index 0 is the closer-date candidate
+    assert "score" in msg
+    assert "Date Δ = 2 day(s)" in msg
+    assert "Payee sim = " in msg
+    # Should also carry human-readable reasons from compare_txn
+    assert "day(s) apart" in msg or "Same date" in msg
+
+
+def test_accessors_pairs_and_unmatched_after_auto_match():
+    """Positive: pairs/unmatched_* accessors reflect current session state deterministically."""
+    bank = _mk_bank(("2025-08-01", "10.00", "A"), ("2025-08-02", "20.00", "B"))
+    excel = _mk_excel(("2025-08-01", "10.00", "A1"))
+    s = ms.MatchSession(bank, excel)
+
+    # Act
+    s.auto_match()
+
+    # Assert
+    assert s.pairs == [(bank[0], excel[0])]
+    assert s.unmatched_bank == [bank[1]]
+    assert s.unmatched_excel == []

--- a/tests/controllers/test_match_session_unit_methods.py
+++ b/tests/controllers/test_match_session_unit_methods.py
@@ -1,346 +1,116 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
+from typing import List, Optional
 
+import pytest
+
+# New API location
 from quicken_helper.controllers.match_session import MatchSession
-from quicken_helper.data_model.excel.excel_row import ExcelRow
-from quicken_helper.data_model.excel.excel_txn_group import ExcelTxnGroup
-from quicken_helper.legacy.qif_item_key import QIFItemKey
-
-# ------------------------------- small helpers --------------------------------
 
 
-def _mk_session(txns, *, groups=None, rows=None) -> MatchSession:
-    """Build a MatchSession with provided QIF and either groups (preferred) or rows."""
-    return MatchSession(txns=txns, excel_groups=groups or [], excel_rows=rows or [])
+# ---------------------------- protocol stubs ----------------------------------
+
+@dataclass(frozen=True)
+class StubTxn:
+    """Minimal ITransaction-shaped stub (date, amount, payee)."""
+    date: date
+    amount: Decimal
+    payee: str = ""
 
 
-def _mk_group(
-    gid: str, d: date, total: str | Decimal, rows: tuple[ExcelRow, ...] = ()
-) -> ExcelTxnGroup:
-    """Convenience for ExcelTxnGroup with Decimal coercion."""
-    return ExcelTxnGroup(gid=gid, date=d, total_amount=Decimal(str(total)), rows=rows)
+def _mk_tx(d: str, a: str, p: str = "") -> StubTxn:
+    y, m, dd = map(int, d.split("-"))
+    return StubTxn(date=date(y, m, dd), amount=Decimal(a), payee=p)
 
 
-def _mk_row(
-    idx: int, gid: str, d: date, amt: str | Decimal, item="i", cat="c", rat="r"
-) -> ExcelRow:
-    """Convenience for ExcelRow with Decimal coercion."""
-    return ExcelRow(
-        idx=idx,
-        txn_id=gid,
-        date=d,
-        amount=Decimal(str(amt)),
-        item=item,
-        category=cat,
-        rationale=rat,
+@pytest.fixture(autouse=True)
+def _identity_convert_value(monkeypatch):
+    """Isolation: treat convert_value as identity (no adapters)."""
+    import quicken_helper.controllers.match_session as ms
+    monkeypatch.setattr(ms, "convert_value", lambda _t, v: v)
+
+
+# ------------------------------ nonmatch_reason -------------------------------
+
+def test_nonmatch_reason_reports_no_equal_amount_candidates():
+    """Negative: when no Excel txn has equal amount, nonmatch_reason should say so and include the amount."""
+    s = MatchSession(
+        txns=[_mk_tx("2025-01-10", "-10.00", "A")],
+        excel_txns=[_mk_tx("2025-01-10", "-9.99", "A")],
+    )
+    msg = s.nonmatch_reason(bank_index=0)
+    assert "No equal-amount candidates" in msg and "10.00" in msg
+
+
+def test_nonmatch_reason_prefers_closer_date_and_mentions_features():
+    """Positive: among equal-amount candidates, the closer date wins; message includes date delta and payee sim."""
+    s = MatchSession(
+        txns=[_mk_tx("2025-01-10", "-10.00", "Acme")],
+        excel_txns=[
+            _mk_tx("2025-01-11", "-10.00", "Acme LLC"),   # 1 day
+            _mk_tx("2025-01-20", "-10.00", "Different"),  # 10 days
+        ],
+    )
+    msg = s.nonmatch_reason(bank_index=0)
+    assert "Best candidate index 0" in msg
+    assert "Date Δ = 1 day(s)" in msg
+    assert "Payee sim =" in msg
+
+
+# -------------------------------- auto_match ----------------------------------
+
+def test_auto_match_greedy_one_to_one_with_threshold():
+    """Positive: auto_match yields one-to-one pairs, respects threshold, and leaves unmatched lists consistent."""
+    s = MatchSession(
+        txns=[_mk_tx("2025-08-01", "10.00", "A"), _mk_tx("2025-08-02", "20.00", "B")],
+        excel_txns=[_mk_tx("2025-08-01", "10.00", "A*"), _mk_tx("2025-08-12", "20.00", "B*")],
     )
 
+    pairs = s.auto_match(min_score=0)  # permissive threshold for the test
 
-# ------------------------------ nonmatch_reason --------------------------------
+    assert len(pairs) == 2
+    assert s.unmatched_bank == []
+    assert s.unmatched_excel == []
 
 
-def test_nonmatch_reason_group_amount_differs():
-    """nonmatch_reason (group mode): returns amount-mismatch reason when totals differ."""
-    qdate = date(2025, 1, 10)
-    session = _mk_session(
-        [{"date": qdate.isoformat(), "amount": "-10.00"}],
-        groups=[_mk_group("G", qdate, "-9.99")],
+# ------------------------------- manual_match ---------------------------------
+
+def test_manual_match_overrides_conflicts_and_is_one_to_one():
+    """Positive: manual_match overrides any conflicting existing pairings, keeping the mapping one-to-one."""
+    s = MatchSession(
+        txns=[_mk_tx("2025-08-01", "10.00"), _mk_tx("2025-08-02", "20.00")],
+        excel_txns=[_mk_tx("2025-08-01", "10.00"), _mk_tx("2025-08-02", "20.00")],
     )
-    q = session.txn_views[0]
-    reason = session.nonmatch_reason(q, session.excel_groups[0])
-    assert (
-        "Total amount differs" in reason
-        and "QIF -10.00" in reason
-        and "Excel group -9.99" in reason
+    # Prime with an initial mapping
+    s.manual_match(0, 0)
+    s.manual_match(1, 1)
+
+    # Now force 0 -> 1, which must unhook 1 -> 1
+    s.manual_match(0, 1)
+
+    assert s.pairs == [(s.bank_txns[0], s.excel_txns[1])]
+    assert s.unmatched_bank == [s.bank_txns[1]]
+    assert s.unmatched_excel == [s.excel_txns[0]]
+
+
+# ------------------------------ manual_unmatch --------------------------------
+
+def test_manual_unmatch_by_bank_and_by_excel_index():
+    """Positive: manual_unmatch removes pairs when called by either bank_index or excel_index."""
+    s = MatchSession(
+        txns=[_mk_tx("2025-08-01", "10.00")],
+        excel_txns=[_mk_tx("2025-08-01", "10.00")],
     )
-
-
-def test_nonmatch_reason_group_date_outside_window():
-    """nonmatch_reason (group mode): returns ±3-days window violation message."""
-    qdate = date(2025, 1, 10)
-    gdate = qdate + timedelta(days=9)
-    session = _mk_session(
-        [{"date": qdate.isoformat(), "amount": "-10.00"}],
-        groups=[_mk_group("G", gdate, "-10.00")],
-    )
-    q = session.txn_views[0]
-    reason = session.nonmatch_reason(q, session.excel_groups[0])
-    assert (
-        "Date outside ±3 days" in reason
-        and qdate.isoformat() in reason
-        and gdate.isoformat() in reason
-    )
-
-
-def test_nonmatch_reason_group_conflicts_and_closer_date():
-    """nonmatch_reason (group mode): reports existing conflicts and the 'closer date' hint.
-
-    We verify two branches:
-      • If the same QIF key is already matched to a different group → 'QIF txn is already matched.'
-      • If date is within window but not equal, it can return 'Auto-match preferred a closer date (day diff = N).'
-    """
-    qdate = date(2025, 1, 10)
-    g1 = _mk_group("G1", qdate, "-10.00")
-    g2 = _mk_group("G2", qdate + timedelta(days=1), "-10.00")
-    session = _mk_session(
-        [{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g1, g2]
-    )
-    q = session.txn_views[0]
-
-    # Mark q as already matched to g1; asking about g2 should yield the "already matched" message.
-    session.qif_to_excel_group[q.key] = 0
-    session.excel_group_to_qif[0] = q.key
-    reason1 = session.nonmatch_reason(q, g2)
-    assert reason1 == "QIF txn is already matched."
-
-    # Remove conflict; now amounts match and day diff = 1 → closer date message.
-    session.qif_to_excel_group.clear()
-    session.excel_group_to_qif.clear()
-    reason2 = session.nonmatch_reason(q, g2)
-    assert reason2.startswith("Auto-match preferred a closer date (day diff = 1)")
-
-
-def test_nonmatch_reason_group_selected_another_candidate_on_tie():
-    """nonmatch_reason (group mode): when amount and date are identical and no conflicts,
-    returns 'Auto-match selected another candidate.' (tie / alternate choice)."""
-    qdate = date(2025, 1, 10)
-    g = _mk_group("G", qdate, "-10.00")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g])
-    q = session.txn_views[0]
-    assert session.nonmatch_reason(q, g) == "Auto-match selected another candidate."
-
-
-def test_nonmatch_reason_legacy_amount_date_conflicts_and_closer():
-    """nonmatch_reason (legacy row mode): amount mismatch, date window fail, row/QIF conflicts, and closer-date hint."""
-    qdate = date(2025, 1, 10)
-    r_ok = _mk_row(0, "A", qdate + timedelta(days=1), "-10.00")
-    r_amt = _mk_row(1, "B", qdate, "-9.99")
-    r_far = _mk_row(2, "C", qdate + timedelta(days=9), "-10.00")
-    session = _mk_session(
-        [{"date": qdate.isoformat(), "amount": "-10.00"}], rows=[r_ok, r_amt, r_far]
-    )
-    q = session.txn_views[0]
-
-    # amount differs
-    assert session.nonmatch_reason(q, r_amt).startswith("Amount differs")
-
-    # date outside window
-    assert "Date outside ±3 days" in session.nonmatch_reason(q, r_far)
-
-    # conflicts on legacy maps
-    # simulate q mapped to another row (different from r_ok.idx)
-    session.qif_to_excel[q.key] = 99
-    assert session.nonmatch_reason(q, r_ok) == "QIF item is already matched."
-    session.qif_to_excel.clear()
-
-    # row mapped to another qkey
-    other_key = QIFItemKey(txn_index=123, split_index=None)
-    session.excel_to_qif[r_ok.idx] = other_key
-    assert session.nonmatch_reason(q, r_ok) == "Excel row is already matched."
-    session.excel_to_qif.clear()
-
-    # closer date hint when diff > 0
-    assert session.nonmatch_reason(q, r_ok).startswith(
-        "Auto-match preferred a closer date (day diff = 1)"
-    )
-
-
-# -------------------------------- manual_match --------------------------------
-
-
-def test_manual_match_group_success_and_unhooks_conflicts():
-    """manual_match (group mode): succeeds when amount matches and date is in-window,
-    unhooks any existing links on both sides, and records the new mapping."""
-    qdate = date(2025, 1, 10)
-    g1 = _mk_group("G1", qdate, "-10.00")
-    g2 = _mk_group("G2", qdate, "-10.00")
-    session = _mk_session(
-        [{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g1, g2]
-    )
-    qkey = session.txn_views[0].key
-
-    # Pre-existing conflicts (wrong links)
-    session.qif_to_excel_group[qkey] = 1
-    session.excel_group_to_qif[1] = qkey
-    other_key = QIFItemKey(99, None)
-    session.excel_group_to_qif[0] = other_key
-    session.qif_to_excel_group[other_key] = 0
-
-    ok, msg = session.manual_match(qkey, excel_idx=0)
-    assert ok and msg == "Matched."
-    assert session.qif_to_excel_group == {qkey: 0}
-    assert session.excel_group_to_qif == {0: qkey}
-
-
-def test_manual_match_group_failure_cases():
-    """manual_match (group mode): rejects bad indices, amount mismatch, date outside window, unknown QIF key."""
-    qdate = date(2025, 1, 10)
-    g = _mk_group("G", qdate + timedelta(days=10), "-9.99")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g])
-    qkey = session.txn_views[0].key
-
-    # Out of range
-    ok, msg = session.manual_match(qkey, excel_idx=1)
-    assert not ok and msg == "Excel group index out of range."
-
-    # Amount differs
-    ok, msg = session.manual_match(qkey, excel_idx=0)
-    assert not ok and msg.startswith("Total amount differs")
-
-    # Date outside ±3
-    # Fix amount to match; keep date far
-    session.excel_groups[0] = _mk_group("G", g.date, "-10.00")
-    ok, msg = session.manual_match(qkey, excel_idx=0)
-    assert not ok and msg.startswith("Date outside ±3 days")
-
-    # Unknown QIF key
-    bad_key = QIFItemKey(999, None)
-    ok, msg = session.manual_match(bad_key, excel_idx=0)
-    assert not ok and msg == "QIF item key not found."
-
-
-def test_manual_match_legacy_success_and_mapping():
-    """manual_match (legacy row mode): when there are no groups, excel_idx is a row index;
-    succeeds if amount matches and date is in-window, and records qif_to_excel/excel_to_qif.
-    """
-    qdate = date(2025, 1, 10)
-    r = _mk_row(0, "A", qdate, "-10.00")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], rows=[r])
-    qkey = session.txn_views[0].key
-
-    ok, msg = session.manual_match(qkey, excel_idx=0)
-    assert ok and msg == "Matched."
-    assert session.qif_to_excel == {qkey: 0}
-    assert session.excel_to_qif == {0: qkey}
-
-
-# ------------------------------- manual_unmatch --------------------------------
-
-
-def test_manual_unmatch_group_by_qkey_and_by_index():
-    """manual_unmatch (group mode): removes existing links when called with qkey or with excel_idx; False when absent."""
-    qdate = date(2025, 1, 10)
-    g = _mk_group("G", qdate, "-10.00")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g])
-    qkey = session.txn_views[0].key
-
-    # Create link
-    session.qif_to_excel_group[qkey] = 0
-    session.excel_group_to_qif[0] = qkey
-
-    # Remove by qkey
-    assert session.manual_unmatch(qkey=qkey) is True
-    assert session.qif_to_excel_group == {} and session.excel_group_to_qif == {}
-
-    # Remove by index (absent now) -> False
-    assert session.manual_unmatch(excel_idx=0) is False
-
-
-def test_manual_unmatch_legacy_paths_via_internal_helpers():
-    """manual_unmatch/_unmatch_qkey/_unmatch_excel: exercise legacy branches by setting
-    session.excel_groups to None, then unlinking legacy maps."""
-    qdate = date(2025, 1, 10)
-    r = _mk_row(0, "A", qdate, "-10.00")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], rows=[r])
-
-    # Manually force legacy-mode behavior inside helpers
-    session.excel_groups = None
-
-    qkey = session.txn_views[0].key
-    session.qif_to_excel[qkey] = 0
-    session.excel_to_qif[0] = qkey
-
-    # By qkey:
-    assert session.manual_unmatch(qkey=qkey) is True
-    assert session.qif_to_excel == {} and session.excel_to_qif == {}
-
-    # Recreate link and remove by excel index (legacy path in _unmatch_excel)
-    session.qif_to_excel[qkey] = 0
-    session.excel_to_qif[0] = qkey
-    assert session.manual_unmatch(excel_idx=0) is True
-    assert session.qif_to_excel == {} and session.excel_to_qif == {}
-
-
-# -------------------------- internal unmatch helpers ---------------------------
-
-
-def test__unmatch_qkey_group_and__unmatch_group_index_symmetry():
-    """_unmatch_qkey_group/_unmatch_group_index: both remove the bi-directional link;
-    return False if nothing to remove."""
-    qdate = date(2025, 1, 10)
-    g = _mk_group("G", qdate, "-10.00")
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}], groups=[g])
-    qkey = session.txn_views[0].key
-
-    # Nothing yet
-    assert session._unmatch_qkey_group(qkey) is False
-    assert session._unmatch_group_index(0) is False
-
-    # Link and remove from both directions
-    session.qif_to_excel_group[qkey] = 0
-    session.excel_group_to_qif[0] = qkey
-    assert session._unmatch_qkey_group(qkey) is True
-    assert session.qif_to_excel_group == {} and session.excel_group_to_qif == {}
-
-    # Recreate and remove by index
-    session.qif_to_excel_group[qkey] = 0
-    session.excel_group_to_qif[0] = qkey
-    assert session._unmatch_group_index(0) is True
-    assert session.qif_to_excel_group == {} and session.excel_group_to_qif == {}
-
-
-def test__unmatch_qkey_and__unmatch_excel_legacy_and_group_modes():
-    """_unmatch_qkey/_unmatch_excel: verify they unlink in the correct maps in both group-mode
-    (excel_groups is not None) and legacy-mode (excel_groups is None)."""
-    qdate = date(2025, 1, 10)
-    session = _mk_session([{"date": qdate.isoformat(), "amount": "-10.00"}])
-
-    qkey = session.txn_views[0].key
-
-    # Group-path: excel_groups defaults to [], which is "not None" for helpers
-    session.qif_to_excel_group[qkey] = 5
-    session.excel_group_to_qif[5] = qkey
-    assert session._unmatch_qkey(qkey) is True
-    assert session.qif_to_excel_group == {} and session.excel_group_to_qif == {}
-
-    session.qif_to_excel_group[qkey] = 6
-    session.excel_group_to_qif[6] = qkey
-    assert session._unmatch_excel(6) is True
-    assert session.qif_to_excel_group == {} and session.excel_group_to_qif == {}
-
-    # Legacy-path: set excel_groups to None, then unlink via legacy maps
-    session.excel_groups = None
-    session.qif_to_excel[qkey] = 7
-    session.excel_to_qif[7] = qkey
-    assert session._unmatch_qkey(qkey) is True
-    assert session.qif_to_excel == {} and session.excel_to_qif == {}
-
-    session.qif_to_excel[qkey] = 8
-    session.excel_to_qif[8] = qkey
-    assert session._unmatch_excel(8) is True
-    assert session.qif_to_excel == {} and session.excel_to_qif == {}
-
-
-# -------------------------------- _group_index ---------------------------------
-
-
-def test__group_index_identity_and_fallback_and_not_found():
-    """_group_index: returns index by identity when the instance is in the list; if a
-    different instance with the same (gid, date, total_amount) is provided, returns the
-    matching index; returns -1 when no match is found."""
-    d = date(2025, 1, 10)
-    g0 = _mk_group("G", d, "-10.00")
-    session = _mk_session([{"date": d.isoformat(), "amount": "-10.00"}], groups=[g0])
-
-    # Identity
-    assert session._group_index(g0) == 0
-
-    # Fallback matching by fields
-    g_equiv = _mk_group("G", d, "-10.00")
-    assert session._group_index(g_equiv) == 0
-
-    # Not found
-    g_other = _mk_group("H", d, "-10.00")
-    assert session._group_index(g_other) == -1
+    s.manual_match(0, 0)
+
+    # Remove by bank index
+    s.manual_unmatch(bank_index=0)
+    assert s.pairs == [] and s.unmatched_bank and s.unmatched_excel
+
+    # Re-pair and remove by excel index
+    s.manual_match(0, 0)
+    s.manual_unmatch(excel_index=0)
+    assert s.pairs == [] and s.unmatched_bank and s.unmatched_excel

--- a/tests/controllers/test_txn_compare.py
+++ b/tests/controllers/test_txn_compare.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+
+from quicken_helper.controllers.transaction_compare import compare_txn
+
+
+@dataclass(frozen=True)
+class StubTxn:
+    """Minimal ITransaction-shaped stub (only attributes used by compare_txn)."""
+    date: Optional[date]
+    amount: Decimal
+    payee: str = ""
+
+
+def _t(d: Optional[str], a: str, p: str) -> StubTxn:
+    """Helper to build a StubTxn from strings."""
+    dt = None if d is None else date.fromisoformat(d)
+    return StubTxn(date=dt, amount=Decimal(a), payee=p)
+
+
+def test_amount_mismatch_is_hard_gate():
+    """Negative: amount mismatch should trigger the hard gate and a negative score with a clear reason."""
+    a = _t("2025-08-01", "10.00", "Acme")
+    b = _t("2025-08-02", "11.00", "Acme")
+
+    ms = compare_txn(a, b)
+
+    assert ms.score < 0, "Amount mismatch must yield a losing/negative score"
+    joined = "; ".join(ms.reasons)
+    assert "Amount differs by" in joined
+    assert ms.features["amount_a"] == "10.00"
+    assert ms.features["amount_b"] == "11.00"
+
+
+def test_date_proximity_scoring_is_monotonic_with_equal_amounts():
+    """Positive: with equal amounts and same payee, closer dates must score higher (0d > 5d > 10d)."""
+    base = _t("2025-08-01", "25.00", "Acme")
+    same_day = _t("2025-08-01", "25.00", "Acme")
+    plus_5 = _t("2025-08-06", "25.00", "Acme")   # 5 days
+    plus_10 = _t("2025-08-11", "25.00", "Acme")  # 10 days
+
+    s0 = compare_txn(base, same_day)
+    s5 = compare_txn(base, plus_5)
+    s10 = compare_txn(base, plus_10)
+
+    assert s0.score > s5.score > s10.score >= 0
+    assert any("Same date" in r for r in s0.reasons), "Same-date case should explain the bonus"
+    assert s5.features["date_days"] == 5
+    assert s10.features["date_days"] == 10
+
+
+def test_payee_similarity_breaks_ties_when_dates_equal():
+    """Positive: with equal amounts and same date, higher payee similarity should yield higher score."""
+    a = _t("2025-08-01", "50.00", "Acme")
+    b_close = _t("2025-08-01", "50.00", "Acme LLC")   # similar
+    b_far = _t("2025-08-01", "50.00", "Different Co") # dissimilar
+
+    ms_close = compare_txn(a, b_close)
+    ms_far = compare_txn(a, b_far)
+
+    assert ms_close.score > ms_far.score
+    assert 0.0 <= ms_close.features["payee_sim"] <= 1.0
+    assert 0.0 <= ms_far.features["payee_sim"] <= 1.0
+    # Should mention payee similarity in reasons
+    assert any("Payee similarity" in r for r in ms_close.reasons)
+    assert any("Payee similarity" in r for r in ms_far.reasons)
+
+
+def test_missing_dates_are_neutral_on_date_component():
+    """Edge: if one side lacks a date, score is based on payee similarity only; reason clarifies neutrality."""
+    a = _t("2025-08-01", "10.00", "Acme")
+    b = _t(None, "10.00", "Acme")  # no date on one side
+
+    ms = compare_txn(a, b)
+
+    assert ms.features["date_days"] is None
+    assert any("No date on one side (+0)" in r for r in ms.reasons)
+    assert ms.score >= 0, "With equal amounts and identical payee, score should be non-negative"
+
+
+def test_features_dictionary_contains_expected_keys_and_types():
+    """Positive: features should include normalized amounts, dates, payees, deltas, and similarity."""
+    a = _t("2025-08-10", "100.00", "Globex")
+    b = _t("2025-08-12", "100.00", "Globex Inc")
+
+    ms = compare_txn(a, b)
+    f = ms.features
+
+    # Presence checks
+    for key in ("amount_a", "amount_b", "amount_diff", "date_a", "date_b", "date_days", "payee_a", "payee_b", "payee_sim"):
+        assert key in f, f"features should contain '{key}'"
+
+    # Type/format sanity
+    assert isinstance(f["amount_a"], str) and isinstance(f["amount_b"], str)
+    assert isinstance(f["amount_diff"], str)
+    # date_a/date_b are ISO strings
+    assert isinstance(f["date_a"], str) and f["date_a"].startswith("2025-08-")
+    assert isinstance(f["date_b"], str) and f["date_b"].startswith("2025-08-")
+    assert isinstance(f["date_days"], int)
+    assert isinstance(f["payee_a"], str) and isinstance(f["payee_b"], str)
+    assert isinstance(f["payee_sim"], float)


### PR DESCRIPTION
# feat: migrate GUI matching to protocol-only; add Excel→ITransaction adapter; explainable matcher; hardened number parsing

**Base:** `origin/development`
**Head:** `feature/migrate-parsing-to-data-model`
**Commits:**

* 98654b8 — feat(gui|data-model|utils): migrate MergeTab to protocol-only flow; add Excel→ITransaction adapter; harden number parsing
* 1bec1ce — feat(matching): add explainable `compare_txn`; +`ExcelTransaction` & `as_transaction`

---

## Why

Move the app off legacy dict/group wiring and onto the new protocol data model end-to-end. This simplifies matching, improves determinism & explainability, and makes ingestion more robust to locale/currency formats.

---

## What’s in here

### Matching / Controllers

* **`controllers/transaction_compare.py`** (new)

  * `compare_txn(a, b)` implements the legacy heuristics with a transparent score:

    * Hard gate on **exact amount**.
    * Score by **date proximity** (base + per-day penalty).
    * Tie-break with **payee similarity** (`SequenceMatcher` on a normalized payee).
  * Returns a `MatchScore(score, reasons, features)` for deterministic sorting & UI “why not” explanations.

* **`controllers/match_session.py`** (refactor)

  * Protocol-only API: `MatchSession(bank_txns, excel_txns)`.
  * Public fields: `.pairs`, `.unmatched_bank`, `.unmatched_excel`.
  * Manual ops now by **index**: `manual_match(bank_index=…, excel_index=…)`, `manual_unmatch(bank_index=…|excel_index=…)`.
  * Deterministic operations and simplified internal structures.

### Data model

* **`data_model/excel/excel_transaction.py`** (new)

  * `ExcelSplit`, `ExcelTransaction` dataclasses implementing `ISplit` / `ITransaction`.
  * `map_group_to_excel_txn(group)` converts an `ExcelTxnGroup` to a single `ITransaction`.

    * Mapping:

      * `id ← gid`
      * `date ← group.date`
      * `amount ← total_amount` (coerced via `_to_decimal`)
      * `payee ← first non-empty row.item`
      * `memo ← unique rationales joined with “; ”`
      * `splits ← one per row (category, memo=item or rationale, amount)`
      * Parent `category` blank if splits exist; `cleared=UNKNOWN`; `action=None`.
* **`data_model/excel/__init__.py`** now exports `map_group_to_excel_txn`.

### Utilities

* **`utilities/data_conversion.py`** (new)

  * `as_transaction(x) -> ITransaction` wrapper over `convert_value` to coerce arbitrary inputs.

* **`utilities/converters_scalar.py`** (hardened)

  * New `clean_number_like_string(...)` and upgraded `_to_decimal(...)`:

    * Handles currency symbols, unicode minus, parentheses or trailing minus.
    * Auto-detects decimal vs thousands for `.`/`,` (if both present, the **last** separator is treated as decimal).
  * `_to_int(...)` now uses the same cleaning logic with clearer errors.

### GUI

* **`gui_viewers/merge_tab.py`**

  * Fully protocol-only flow:

    * Bank side via `load_transactions_protocol(...)`.
    * Excel side: `ExcelTxnGroup → map_group_to_excel_txn(...) → ITransaction`.
    * `MatchSession(bank_txns, excel_txns)`.
  * List plumbings & actions rewritten to use **indices**; previews resilient to missing optional attrs.
  * Tolerant `_cleared_to_char(...)` that accepts enum/string/bool/int/None.
  * Better error handling; logs use `logger.exception(...)`.

* **`gui_viewers/app.py`**

  * Initializes logging via `logging.config.dictConfig(LOGGING)`.

### Tooling

* **`.pre-commit-config.yaml`** (new)

  * Lightweight pygrep hooks to prevent accidental DELETE marker blocks and similar footguns.

### Tests

* **Controllers & GUI tests updated** to the protocol-only API.
* **New** `tests/controllers/test_txn_compare.py` for the scorer.

---

## Scope & impact

* **Net change:** 1,700 insertions / 1,808 deletions (−108 LOC).
* **User-visible behavior:** No functional regressions expected. GUI lists, previews, and match/unmatch should behave the same or better (more deterministic ordering, clearer error messages).
* **API changes (internal):**

  * `MatchSession` now constructed with `(bank_txns, excel_txns)` and exposes `.pairs`, `.unmatched_bank`, `.unmatched_excel`.
  * Manual match/unmatch now index-based (no `QIFItemKey` needed).
  * Excel ingestion should adapt `ExcelTxnGroup` via `map_group_to_excel_txn(...)`.

---

## Migration notes (for downstream callers)

* Replace:

  ```python
  MatchSession(txns, excel_groups)
  s.manual_match(qkey=..., excel_idx=...)
  s.manual_unmatch(qkey=... | excel_idx=...)
  s.matched_pairs(), s.unmatched_qif(), s.unmatched_excel()
  ```

  with:

  ```python
  MatchSession(bank_txns, excel_txns)
  s.manual_match(bank_index=..., excel_index=...)
  s.manual_unmatch(bank_index=... | excel_index=...)
  s.pairs, s.unmatched_bank, s.unmatched_excel
  ```

* If you were consuming Excel groups directly, use:

  ```python
  from quicken_helper.data_model.excel import map_group_to_excel_txn
  excel_txns = [map_group_to_excel_txn(g) for g in groups]
  ```

* When coercing arbitrary inputs to the protocol, prefer:

  ```python
  from quicken_helper.utilities.data_conversion import as_transaction
  t = as_transaction(obj)
  ```

---

## Risk assessment

* **Matching correctness:** The scorer preserves legacy gates and augments explainability; unit tests cover common paths.
* **Locale/number parsing:** `_to_decimal` auto-detection could be surprising for unusual formats; ambiguous cases fall back to treating the earlier separator as thousands and the last as the decimal (documented).
* **GUI selection semantics:** Index-based operations reduce reliance on object identity; list refresh paths were updated and tested.

Mitigations: comprehensive test updates, deterministic sort keys, and verbose logging on exceptions.

---

## Testing

* **Automated:** Updated/added tests:

  * Controllers: matching session CRUD + scorer.
  * GUI: list plumbing, manual match/unmatch, previews.
* **Manual smoke (recommended):**

  1. Open Merge tab, load a sample QIF and Excel workbook.
  2. Verify matched pairs populate deterministically.
  3. Manually match one bank item to one Excel item; then unmatch via pairs list.
  4. Toggle previews; confirm QIF/Excel details look sane.
  5. Try amounts with `,` and `.` thousands/decimal markers; confirm they parse as expected.

Run:

```bash
pytest -q
```

---

## Out of scope / follow-ups

* Exposing “why not matched” reasoning in the GUI using `MatchScore.reasons`.
* Documenting number-parsing edge cases in user-facing docs.
* Optional: pass a fixed `decimal_char` to `_to_decimal` in sources that guarantee a locale.

---

## Checklist

* [x] Unit tests updated/added
* [x] Logging wired (`LOGGING` config)
* [x] Pre-commit guard added
* [x] Backwards-compat shims not required (internal API only)
* [ ] Add GUI “Why not matched?” tooltip using `compare_txn` reasons (follow-up)

---

## File summary (high level)

* **Added:** `.pre-commit-config.yaml`, `controllers/transaction_compare.py`, `data_model/excel/excel_transaction.py`, `utilities/data_conversion.py`
* **Modified (high-impact):** `controllers/match_session.py`, `gui_viewers/merge_tab.py`, `utilities/converters_scalar.py`
* **Tests:** `tests/controllers/test_txn_compare.py` (new), multiple updates across controller & GUI suites
